### PR TITLE
adds a test to make sure popping the remaining element works

### DIFF
--- a/src/data_structures/linkedlist.rs
+++ b/src/data_structures/linkedlist.rs
@@ -207,6 +207,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_push_and_pop() {
+        let mut new_list = LinkedList::<i32>::new();
+        new_list.push(0);
+        new_list.pop();
+        assert_eq!(new_list.len(), 0);
+    }
+
+    #[test]
     fn test_push_back_length() {
         let mut new_list = LinkedList::<i32>::new();
         let values = (0..10).collect::<Vec<i32>>();


### PR DESCRIPTION
This pull-request adds a test that panics.

I read your [Writing a Linked List in Rust](https://cmooneycollett.github.io/2023/07/01/writing-a-linkedlist-in-rust) article and fiddled with the code a bit and saw that it will panic if the last element is popped off.